### PR TITLE
Allow compute to be placed on two different executors

### DIFF
--- a/tests/specify/test_spec.py
+++ b/tests/specify/test_spec.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from csv import writer
 import json
 
-from parsl import Config
+from parsl import Config, HighThroughputExecutor
 from parsl.configs import htex_local
 from pytest import fixture, raises
 from sklearn.pipeline import Pipeline
@@ -73,9 +73,20 @@ def simulator(tmp_path):
     return ASESimulator(scratch_dir=tmp_path)
 
 
-@fixture()
-def config(tmp_path) -> Config:
-    config = htex_local.config
+@fixture(params=['single', 'split'])
+def config(request, tmp_path) -> Config:
+    if request.param == 'single':
+        config = htex_local.config
+    elif request.param == 'split':
+        config = Config(
+            executors=[
+                HighThroughputExecutor(label='learning', max_workers=1),
+                HighThroughputExecutor(label='simulation', max_workers=1)
+            ]
+        )
+    else:
+        raise NotImplementedError()
+
     config.run_dir = tmp_path
     return config
 


### PR DESCRIPTION
Many of our workflows involve simulation and learning apps with distinctly different compute requirements. This PR introduces the ability for users to specify a different compute layout, and have ExaMol partition tasks being resources according to type.

Rather than a general approach, we opt to layouts distinguished by the number and labels of each Parsl executor.