### PR TITLE
Launch reporters as background threads

### DIFF
--- a/examol/cli.py
+++ b/examol/cli.py
@@ -62,11 +62,15 @@ def run_examol(args):
     doer.start()  # Run the doer as a subprocess
     reporter_threads = []
     try:
-        thinker.run()  # Run the thinker on the main thread
+        thinker.start()  # Start the thinker
+        logger.info('Launched the thinker. Waiting a second before launching the reporters')
 
         # Start the monitors
         for reporter in spec.reporters:
             reporter_threads.append(reporter.monitor(thinker, args.report_freq))
+        logger.info('Launched the reporting threads')
+
+        thinker.join()  # Wait until it completes
     finally:
         logger.info('Thinker complete, sending a signal to shut down the doer')
         thinker.done.set()  # Make sure it is set

--- a/examol/cli.py
+++ b/examol/cli.py
@@ -70,7 +70,11 @@ def run_examol(args):
             reporter_threads.append(reporter.monitor(thinker, args.report_freq))
         logger.info('Launched the reporting threads')
 
-        thinker.join()  # Wait until it completes
+        thinker.join(timeout=args.timeout)  # Wait until it completes
+    except TimeoutError:
+        logger.info('Hit timeout. Sending stop signal to Thinker then blocking until all ongoing tasks complete')
+        thinker.done.set()  # If it hits the timeout
+        thinker.join()
     finally:
         logger.info('Thinker complete, sending a signal to shut down the doer')
         thinker.done.set()  # Make sure it is set
@@ -101,6 +105,7 @@ def main(args: list[str] | None = None):
     subparser = subparsers.add_parser('run', help='Run ExaMol')
     subparser.add_argument('--dry-run', action='store_true', help='Load in configuration but do not start computing')
     subparser.add_argument('--report-freq', default=10, type=float, help='How often to write run status (units: s)')
+    subparser.add_argument('--timeout', default=None, type=float, help='Maximum time to let ExaMol run (units: s)')
     subparser.add_argument('spec', help='Path to the run specification. Format is the path to a Python file containing the spec, '
                                         'followed by a colon and the name of the variable defining the specification (e.g., `spec.py:spec`)')
 

--- a/examol/reporting/markdown.py
+++ b/examol/reporting/markdown.py
@@ -64,9 +64,14 @@ class MarkdownReporter(BaseReporter):
     def _plot_over_time(self, fo: TextIO, thinker: SingleObjectiveThinker):
         """Plot the properties evaluated over time"""
 
+        # Exit if simulation results do not exist yet
+        simulation_results = thinker.run_dir / 'simulation-results.json'
+        if not simulation_results.exists():
+            return
+
         # Load in the simulation results. The computed property is stored in 'value'
         results = []
-        with open(thinker.run_dir / 'simulation-results.json') as fp:
+        with simulation_results.open() as fp:
             for line in fp:
                 record = json.loads(line)
                 if 'result' in record['task_info']:

--- a/examol/specify.py
+++ b/examol/specify.py
@@ -84,8 +84,8 @@ class ExaMolSpecification:
         if len(exec_names) == 1:  # Case 1: All to the
             methods = [self.scorer.score, self.scorer.retrain, self.simulator.optimize_structure, self.simulator.compute_energy]
         elif exec_names == {'learning', 'simulation'}:
-            methods = [(x, {'executors': 'learning'}) for x in [self.scorer.score, self.scorer.retrain]]
-            methods += [(x, {'executors': 'simulation'}) for x in [self.simulator.optimize_structure, self.simulator.compute_energy]]
+            methods = [(x, {'executors': ['learning']}) for x in [self.scorer.score, self.scorer.retrain]]
+            methods += [(x, {'executors': ['simulation']}) for x in [self.simulator.optimize_structure, self.simulator.compute_energy]]
         else:
             raise NotImplementedError(f'We do not support the executor layout: {",".join(exec_names)}')
 

--- a/examol/steer/single.py
+++ b/examol/steer/single.py
@@ -158,7 +158,7 @@ class SingleObjectiveThinker(MoleculeThinker):
                 self.completed += 1
                 if self.completed == self.num_to_run:
                     self.done.set()
-                self.logger.info(f'Finished computing recipe for {mol_key}')
+                self.logger.info(f'Finished computing recipe for {mol_key}. Completed {self.completed}/{self.num_to_run} molecules')
                 self.start_training.set()
 
                 # Mark that we've finished with this recipe

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -29,3 +29,13 @@ def test_full(caplog):
 
     # Make sure the database got reported
     assert (_spec_dir / 'run' / 'database.json').is_file()
+
+
+@mark.timeout(240)
+def test_timeout(caplog):
+    with caplog.at_level(logging.INFO):
+        main(['run', '--timeout', '5', f'{_spec_dir / "spec.py"}:spec'])
+    assert any(m.startswith('Find run details in') for m in caplog.messages)
+
+    # Make sure the database got reported
+    assert (_spec_dir / 'run' / 'database.json').is_file()


### PR DESCRIPTION
There's also a fix in here for Parsl. Executors must be a list of strings, not a single string.