### PR TITLE
Skip appropriate sections from coverage

### DIFF
--- a/examol/score/nfp.py
+++ b/examol/score/nfp.py
@@ -3,7 +3,7 @@
 from sklearn.model_selection import train_test_split
 try:
     from tensorflow.keras import callbacks as cb
-except ImportError as e:  # no-coverage
+except ImportError as e:  # pragma: no-coverage
     raise ImportError('You may need to install Tensorflow and NFP.') from e
 import tensorflow as tf
 import numpy as np
@@ -31,7 +31,7 @@ class ReduceAtoms(tf.keras.layers.Layer):
         config['reduction_op'] = self.reduction_op
         return config
 
-    def call(self, inputs, mask=None):  # no-coverage
+    def call(self, inputs, mask=None):  # pragma: no-coverage
         """
         Args:
             inputs: Matrix to be reduced

--- a/examol/score/rdkit/descriptors.py
+++ b/examol/score/rdkit/descriptors.py
@@ -43,7 +43,7 @@ def compute_doan_2020_fingerprints(smiles: str) -> np.ndarray:
     for i, (_, func) in enumerate(_descriptor_list):
         try:
             output[i] = func(mol)
-        except Exception:  # no-coverage
+        except Exception:  # pragma: no-coverage
             pass
     return output
 

--- a/examol/select/botorch.py
+++ b/examol/select/botorch.py
@@ -3,7 +3,7 @@ from typing import List, Any, Callable
 
 try:
     from botorch.acquisition import AcquisitionFunction
-except ImportError as e:  # no-coverage
+except ImportError as e:  # pragma: no-coverage
     raise ImportError('You may need to install BOTorch and PyTorch') from e
 from botorch.models.ensemble import EnsembleModel
 from botorch.models.model import Model

--- a/examol/simulate/ase/utils.py
+++ b/examol/simulate/ase/utils.py
@@ -47,7 +47,7 @@ def make_ephemeral_calculator(calc: Calculator | dict) -> Iterator[Calculator]:
         #  when the object is finally garbage collected
         try:
             calc.__del__()
-        except AssertionError as e:  # no-coverage
+        except AssertionError as e:  # pragma: no-coverage
             logger.info(f'CP2K was noisy on failure: {e}')
             pass
         calc._shell = None


### PR DESCRIPTION
I attempted to mark some sections as "no coverage," but had a few typos in the markings. 

We mark coverage for things like PyTorch/TF layers, which don't work with coverage.py, and error conditions that are below the level I want to test for (e.g., warnings that packages are not installed)