### PR TITLE
Add EHVI, our first multi-objective selector

### DIFF
--- a/docs/components/select.rst
+++ b/docs/components/select.rst
@@ -38,6 +38,11 @@ ExaMol includes selectors that have a variety of characteristics
      - ✘
      - ✘
      - ✘
+   * - :class:`~examol.select.botorch.EHVISelector`
+     - Bayesian
+     - ✔
+     - ✘
+     - ✘
 
 \* Interface to many classes of selection algorithms
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'parsl': ('https://parsl.readthedocs.io/en/stable/', None),
                        'colmena': ('https://colmena.readthedocs.io/en/stable/', None),
                        'proxystore': ('https://docs.proxystore.dev/main/', None)}
-autodoc_mock_imports = ["tensorflow", "sklearn", "torch", "botorch"]
+autodoc_mock_imports = ["tensorflow", "sklearn", "torch", "botorch", "gpytorch"]
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/envs/environment-cpu.yml
+++ b/envs/environment-cpu.yml
@@ -4,6 +4,7 @@ name: examol
 channels:
   - defaults
   - conda-forge
+  - pytorch
 dependencies:
   - python==3.10.*
   - pandas==1.*
@@ -13,6 +14,12 @@ dependencies:
   - jupyterlab
   - matplotlib
   - pytest
+
+  # Use Conda PyTorch to avoid OpenMP disagreement
+  #  with xTB
+  - pytorch==2.0.*
+  - cpuonly
+
   - pip
   - pip:
     # Need TF for NFP MPNNs
@@ -20,6 +27,4 @@ dependencies:
     - nfp
     
     # Need torch for BOTorch
-    - --extra-index-url https://download.pytorch.org/whl/cpu
-    - torch==2.0.1+cpu
     - -e ..[botorch,test]

--- a/envs/environment-cu118.yml
+++ b/envs/environment-cu118.yml
@@ -1,9 +1,11 @@
-# Environment that uses a locally-installed CUDA 11.8
+# Environment that uses CUDA 11.8
 #  Installs packages needed for all features
 name: examol
 channels:
   - defaults
   - conda-forge
+  - pytorch
+  - nvidia
 dependencies:
   - python==3.10.*
   - pandas==1.*
@@ -12,14 +14,16 @@ dependencies:
   - pymongo
   - jupyterlab
   - matplotlib
+
+  # Need torch for BOTorch
+  - pytorch==2.0.*
+  - pytorch-cuda==11.8
+
   - pytest
   - pip
   - pip:
-    # Need TF for NFP MPNNs
-    - tensorflow
-    - nfp
-    
-    # Need torch for BOTorch
-    - --extra-index-url https://download.pytorch.org/whl/cu118
-    - torch==2.0.1+cu118
-    - -e ..[botorch,test]
+      # Need TF for NFP MPNNs
+      - tensorflow
+      - nfp
+
+      - -e ..[botorch,test]

--- a/examol/select/base.py
+++ b/examol/select/base.py
@@ -130,7 +130,7 @@ class RankingSelector(Selector):
     """Base class where we assign an independent score to each possibility.
 
     Implementations must return high scores for desired entries
-    regardless of whether the the selector is set to minimize.
+    regardless of whether the selector is set to minimize.
 
     Args:
         to_select: How many computations to select per batch

--- a/examol/select/base.py
+++ b/examol/select/base.py
@@ -83,14 +83,13 @@ class Selector:
         Args:
             keys: Labels by which to identify the records being evaluated
             samples: A distribution of scores for each record.
-                Expects a two-dimensional array where each row is a different record,
-                and each column is a different model.
+                Expects a 3-dimensional array of shape (num recipes) x (num records) x (num models)
         """
         # Test for error conditions
         if samples.shape[0] > 1 and not self.multiobjective:
             raise ValueError(f'Provided {samples.shape[0]} objectives but the class does not support multi-objective selection')
         if samples.ndim != 3:  # pragma: no-coverage
-            raise ValueError(f'Expected samples dimension of 3. Found {samples.ndim}. Array should be (recipe, sample, model)')
+            raise ValueError(f'Expected samples dimension of 3. Found {samples.ndim}. Array should be (recipe, records, model)')
         if samples.shape[1] != len(keys):  # pragma: no-coverage
             raise ValueError(f'Number of keys and number of samples differ. Keys={len(keys)}. Samples={samples.shape[1]}')
 
@@ -129,19 +128,38 @@ class Selector:
 class RankingSelector(Selector):
     """Base class where we assign an independent score to each possibility.
 
-    Implementations must return high scores for desired entries
-    regardless of whether the selector is set to minimize.
+    Implementations should assume that the goal is maximization
+    because this abstract class negates the samples for objective
+    is to minimize.
 
     Args:
         to_select: How many computations to select per batch
-        maximize: Whether to select entries with high or low values of the samples
+        maximize: Whether to select entries with high or low values of the samples.
+            Provide either a single value if maximizing or minimizing all objectives,
+            or a list for whether to maximize each objectives.
     """
-    def __init__(self, to_select: int, maximize: bool = True):
+
+    def __init__(self, to_select: int, maximize: bool | Sequence[bool] = True):
         self._options: list[tuple[object, float]] = []
         self.maximize = maximize
         super().__init__(to_select)
 
     def _add_possibilities(self, keys: list, samples: np.ndarray, **kwargs):
+        # Determine user options for minimization
+        n_objectives = samples.shape[0]
+        maximize = self.maximize
+        if isinstance(maximize, bool):
+            maximize = [maximize] * n_objectives
+        elif len(maximize) != n_objectives:  # pragma: no-cover
+            raise ValueError(f'Different number of recipes ({n_objectives} and number of maximization selections ({len(maximize)})')
+
+        # Negate, if needed
+        if not all(maximize):
+            samples = samples.copy()
+            for i, m in enumerate(maximize):
+                if not m:
+                    samples[i, :, :] *= -1
+
         score = self._assign_score(samples)
         self._options = heapq.nlargest(self.to_select, chain(self._options, zip(keys, score)), key=lambda x: x[1])
 

--- a/examol/select/baseline.py
+++ b/examol/select/baseline.py
@@ -32,6 +32,4 @@ class GreedySelector(RankingSelector):
 
     def _assign_score(self, samples):
         mean = np.mean(samples, axis=(0, 2))
-        if not self.maximize:
-            mean *= -1
         return mean

--- a/examol/select/bayes.py
+++ b/examol/select/bayes.py
@@ -25,7 +25,7 @@ class ExpectedImprovement(RankingSelector):
 
     def update(self, database: dict[str, MoleculeRecord], recipes: Sequence[PropertyRecipe]):
         values = _extract_observations(database, recipes)
-        self.best_so_far = max(values) if self.maximize else min(values)
+        self.best_so_far = max(values) if self.maximize else -min(values)
 
     def _assign_score(self, samples: np.ndarray) -> np.ndarray:
         # Compute the mean and standard deviation for each entry
@@ -34,8 +34,4 @@ class ExpectedImprovement(RankingSelector):
 
         # If we are minimizing, invert the values
         max_y = self.best_so_far
-        if not self.maximize:
-            mean *= -1
-            max_y = max_y * -1
-
         return EI(mean, std, max_val=max_y, tradeoff=self.epsilon)

--- a/examol/select/botorch.py
+++ b/examol/select/botorch.py
@@ -118,10 +118,6 @@ class BOTorchSequentialSelector(RankingSelector):
         self.acq_function = self.acq_function_type(model=_EnsembleCovarianceModel(len(recipes)), **self.acq_options)
 
     def _assign_score(self, samples: np.ndarray) -> np.ndarray:
-        # Change sign if need be
-        if not self.maximize:
-            samples = -1 * samples
-
         # Shape the tensor in the form expected by BOtorch's GPyTorch
         #  Samples is a `objectives x samples x models` array
         #  BOTorch expects `samples x batch size (q) x (objectives x models)` array

--- a/tests/select/conftest.py
+++ b/tests/select/conftest.py
@@ -5,13 +5,13 @@ from examol.store.models import MoleculeRecord
 from examol.store.recipes import PropertyRecipe
 
 
+class TestRecipe(PropertyRecipe):
+    pass
+
+
 @fixture()
 def recipe() -> PropertyRecipe:
-    class TestRecipe(PropertyRecipe):
-        def __init__(self):
-            super().__init__('test', 'test')
-
-    return TestRecipe()
+    return TestRecipe('test', 'test')
 
 
 @fixture()
@@ -19,7 +19,7 @@ def test_data():
     # New points
     x = np.linspace(0, 1, 32)
     y = x * (1 - x)
-    y = np.random.normal(scale=0.001, size=(32, 8)) + y[None, :, None]
+    y = np.random.normal(scale=0.01, size=(32, 8)) + y[None, :, None]
 
     # Example database
     record = MoleculeRecord.from_identifier('C')

--- a/tests/select/conftest.py
+++ b/tests/select/conftest.py
@@ -1,5 +1,8 @@
+from botorch.test_functions.multi_objective import BraninCurrin
+from botorch.utils import draw_sobol_samples
 from pytest import fixture
 import numpy as np
+import torch
 
 from examol.store.models import MoleculeRecord
 from examol.store.recipes import PropertyRecipe
@@ -26,3 +29,29 @@ def test_data():
     record.properties['test'] = {'test': 0.25}
     record_2 = MoleculeRecord.from_identifier('O')
     return x, y, {record.key: record, record_2.key: record_2}
+
+
+@fixture()
+def multi_recipes() -> list[PropertyRecipe]:
+    return [TestRecipe('a', 'test'), TestRecipe('b', 'test')]
+
+
+@fixture()
+def multi_test_data() -> tuple[np.ndarray, np.ndarray, dict[str, MoleculeRecord]]:
+    problem = BraninCurrin(negate=True)
+    train_x = draw_sobol_samples(bounds=problem.bounds, n=8, q=1).squeeze(1)
+    train_y = problem(train_x)
+    train_mols = {}
+    for i, y in enumerate(train_y):
+        record = MoleculeRecord.from_identifier('C' * (i + 1))
+        record.properties = {'a': {'test': y[0]}, 'b': {'test': y[1]}}
+        train_mols[record.key] = record
+
+    # Make some test points
+    sample_x = draw_sobol_samples(bounds=problem.bounds, n=32, q=1).squeeze(1)
+    sample_y = problem(sample_x).T  # Will be (num objectives) x (num samples)
+    sample_y = torch.unsqueeze(sample_y, dim=-1)
+    sample_y = torch.tile(sample_y, dims=[1, 1, 8])
+    sample_y += torch.rand(*sample_y.shape) * 0.1
+
+    return sample_x.numpy(), sample_y.numpy(), train_mols

--- a/tests/select/conftest.py
+++ b/tests/select/conftest.py
@@ -22,7 +22,7 @@ def test_data():
     # New points
     x = np.linspace(0, 1, 32)
     y = x * (1 - x)
-    y = np.random.normal(scale=0.01, size=(32, 8)) + y[None, :, None]
+    y = np.random.normal(scale=0.001, size=(32, 8)) + y[None, :, None]
 
     # Example database
     record = MoleculeRecord.from_identifier('C')

--- a/tests/select/test_botorch.py
+++ b/tests/select/test_botorch.py
@@ -1,20 +1,32 @@
 """Tests for the BOTorch-based acquisition functions"""
+from botorch.acquisition import ExpectedImprovement
+from botorch.acquisition.multi_objective import qExpectedHypervolumeImprovement
+from botorch.sampling import SobolQMCNormalSampler
+from botorch.test_functions.multi_objective import BraninCurrin
+from botorch.utils import draw_sobol_samples
 import numpy as np
-from botorch.acquisition import qExpectedImprovement
+import torch
+from botorch.utils.multi_objective.box_decompositions import FastNondominatedPartitioning
 
 from examol.select.botorch import BOTorchSequentialSelector
+
+from conftest import TestRecipe
+from examol.store.models import MoleculeRecord
 
 
 def test_sequential(test_data, recipe):
     """Use EI as a simple test case"""
     x, y, db = test_data
 
-    def update_fn(obs: np.ndarray, options: dict) -> dict:
-        options['best_f'] = max(obs)
+    def update_fn(selector: BOTorchSequentialSelector, obs: np.ndarray) -> dict:
+        options = selector.acq_options.copy()
+        options['best_f'] = max(obs) if selector.maximize else min(obs)
         return options
 
-    selector = BOTorchSequentialSelector(qExpectedImprovement, acq_options={'best_f': 0.5},
-                                         acq_options_updater=update_fn, to_select=1)
+    selector = BOTorchSequentialSelector(ExpectedImprovement,
+                                         acq_options={'best_f': 0.5},
+                                         acq_options_updater=update_fn,
+                                         to_select=1)
     selector.update(db, [recipe])
     assert selector.acq_options['best_f'] == 0.25
 
@@ -25,9 +37,51 @@ def test_sequential(test_data, recipe):
 
     # Test for minimize
     selector.maximize = False
-    selector.acq_options_updater = lambda ob, op: update_fn(-ob, op)
     selector.update(db, [recipe])
     selector.start_gathering()
     selector.add_possibilities(x, -y)
     sel_x, sel_y = zip(*selector.dispense())
     assert (np.abs(np.subtract(sel_x, 0.5)) < 0.1).all()
+
+
+def test_evhi():
+    # Make two recipes
+    test_recipes = [TestRecipe('a', 'test'), TestRecipe('b', 'test')]
+
+    # Set up the problem and the initial training set
+    problem = BraninCurrin(negate=True)
+    train_x = draw_sobol_samples(bounds=problem.bounds, n=8, q=1).squeeze(1)
+    train_y = problem(train_x)
+    train_mols = {}
+    for i, y in enumerate(train_y):
+        record = MoleculeRecord.from_identifier('C' * (i + 1))
+        record.properties = {'a': {'test': y[0]}, 'b': {'test': y[1]}}
+        train_mols[record.key] = record
+
+    # Make some test points
+    sample_x = draw_sobol_samples(bounds=problem.bounds, n=32, q=1).squeeze(1)
+    sample_y = problem(sample_x).T  # Will be (num objectives) x (num samples)
+    sample_y = torch.unsqueeze(sample_y, dim=-1)
+    sample_y = torch.tile(sample_y, dims=[1, 1, 8])
+    sample_y += torch.rand(*sample_y.shape) * 0.1
+
+    # Create the sampler
+    def update_fn(selector: BOTorchSequentialSelector, obs: np.ndarray) -> dict:
+        options = selector.acq_options.copy()
+        options['ref_point'] = obs.min(axis=0)
+        options['partitioning'] = FastNondominatedPartitioning(
+            ref_point=problem.ref_point,
+            Y=torch.from_numpy(obs),
+        )
+        return options
+
+    selector = BOTorchSequentialSelector(qExpectedHypervolumeImprovement,
+                                         acq_options={'sampler': SobolQMCNormalSampler(sample_shape=torch.Size([16]))},
+                                         acq_options_updater=update_fn,
+                                         to_select=1)
+
+    selector.update(train_mols, test_recipes)
+
+    # Test maximization
+    selector.add_possibilities(sample_x, sample_y.detach().numpy())
+    sel_x, sel_y = zip(*selector.dispense())

--- a/tests/select/test_botorch.py
+++ b/tests/select/test_botorch.py
@@ -64,3 +64,20 @@ def test_evhi(multi_test_data, multi_recipes):
     selector.add_possibilities(sample_x, sample_y)
     sel_x, sel_y = zip(*selector.dispense())
     assert sel_y[0] > sel_y[1]
+    assert (np.abs(np.subtract(np.pi / 4, sel_x)) < 0.2).all()  # Best points are near Pi/4
+
+    # Test minimizing both
+    sample_y *= -1
+    selector.maximize = False
+    selector.add_possibilities(sample_x, sample_y)
+    sel_x, sel_y = zip(*selector.dispense())
+    assert sel_y[0] > sel_y[1]
+    assert (np.abs(np.subtract(np.pi / 4, sel_x)) < 0.2).all()  # Best points are near Pi/4
+
+    # Test maximizing one objective and minimizing the other
+    sample_y[0, :, :] *= -1
+    selector.maximize = [True, False]
+    selector.add_possibilities(sample_x, sample_y)
+    sel_x, sel_y = zip(*selector.dispense())
+    assert sel_y[0] > sel_y[1]
+    assert (np.abs(np.subtract(np.pi / 4, sel_x)) < 0.2).all()  # Best points are near Pi/4


### PR DESCRIPTION
Adds the EVHI algorithm, following work by [Doan et al](https://pubs.acs.org/doi/full/10.1021/acs.chemmater.1c02040)

Required changing how we define whether objective functions are to be maximized, and how we define the posterior distribution. 