### PR TITLE
Fix adiabatic redox energy being larger than vertical

### DIFF
--- a/examol/store/recipes.py
+++ b/examol/store/recipes.py
@@ -153,11 +153,11 @@ class PropertyRecipe:
                     )
                     continue
 
-                # Get the conformer with the closest charge or the most-recent addition
-                best_score = (float('inf'), float('inf'))
+                # Preference conformers created using the same method followed by same charge, followed by creation date
+                best_score = (True, float('inf'), float('inf'))
                 best_xyz = None
                 for conf in record.conformers:
-                    my_score = (abs(conf.charge - geometry.charge), -conf.date_created.timestamp())
+                    my_score = (conf.config_name != geometry.config_name, abs(conf.charge - geometry.charge), -conf.date_created.timestamp())
                     if my_score < best_score:
                         best_score = my_score
                         best_xyz = conf.xyz

--- a/tests/simulation/test_problem_recipes.py
+++ b/tests/simulation/test_problem_recipes.py
@@ -14,7 +14,7 @@ is_mac = platform.startswith("darwin")
 @fixture()
 def simulator() -> ASESimulator:
     simulator = ASESimulator(clean_after_run=False)
-    rmtree(simulator.scratch_dir)
+    rmtree(simulator.scratch_dir, ignore_errors=True)
     return simulator
 
 

--- a/tests/simulation/test_problem_recipes.py
+++ b/tests/simulation/test_problem_recipes.py
@@ -1,0 +1,51 @@
+"""Tests for combinations of recipe and molecule which fail"""
+from shutil import rmtree
+from sys import platform
+
+from pytest import fixture, mark
+
+from examol.simulate.ase import ASESimulator
+from examol.store.models import MoleculeRecord
+from examol.store.recipes import RedoxEnergy
+
+is_mac = platform.startswith("darwin")
+
+
+@fixture()
+def simulator() -> ASESimulator:
+    simulator = ASESimulator(clean_after_run=False)
+    rmtree(simulator.scratch_dir)
+    return simulator
+
+
+@mark.skipif(is_mac, reason='No xTB on OSX tests')
+def test_no_relaxed_charged(simulator: ASESimulator):
+    """A test where we do not create a new conformer after relaxation"""
+
+    # Make the problem case
+    record = MoleculeRecord.from_identifier('N#CC1OC2CC2C1=O')
+    recipes = [
+        RedoxEnergy(energy_config='mopac_pm7', charge=1, vertical=False),
+        RedoxEnergy(energy_config='mopac_pm7', charge=1, vertical=True),
+        RedoxEnergy(energy_config='xtb', charge=1, vertical=True),
+        RedoxEnergy(energy_config='xtb', charge=1, vertical=False)
+    ]
+
+    # Perform the recipe
+    for recipe in recipes:
+        while len(suggestions := recipe.suggest_computations(record)) > 0:
+            for suggestion in suggestions:
+                if suggestion.optimize:
+                    result, steps, _ = simulator.optimize_structure(record.key, suggestion.xyz, suggestion.config_name, suggestion.charge, suggestion.solvent)
+                    assert record.add_energies(result, steps), 'No new conformer was added'
+                else:
+                    result, _ = simulator.compute_energy(record.key, suggestion.xyz, suggestion.config_name, suggestion.charge, suggestion.solvent)
+                    record.add_energies(result)
+
+        # Compute the result
+        try:
+            recipe.update_record(record)
+        except ValueError:
+            with open('failed.json', 'w') as fp:
+                print(record.to_json(indent=2), file=fp)
+            raise


### PR DESCRIPTION
Fixes #95 , which occurs because the lowest energy structure for a nonzero charge state is the vertical geometry and not the relaxed one. 

This PR changes the starting geometry selection to preference geometries produced using the same level of theory over those taken at the same charge state. Starting from the same method should be more reliable because it decreases the chance that relaxations start from a problematic geometry produced from a different computational method.