### PR TITLE
Screen conformers by whether optimized

### DIFF
--- a/examol/store/models.py
+++ b/examol/store/models.py
@@ -248,13 +248,15 @@ class MoleculeRecord(Document):
             self.conformers[my_match].add_energy(result)
             return False
 
-    def find_lowest_conformer(self, config_name: str, charge: int, solvent: str | None) -> tuple[Conformer, float]:
+    def find_lowest_conformer(self, config_name: str, charge: int, solvent: str | None, optimized_only: bool = True) -> tuple[Conformer, float]:
         """Get the energy of the lowest-energy conformer of a molecule in a certain state
 
         Args:
             config_name: Name of the compute configuration
             charge: Charge of the molecule
             solvent: Solvent in which the molecule is dissolved
+            optimized_only: Only match conformers which were optimized
+                with the specified configuration and charge
         Returns:
             - Lowest-energy conformer
             - Energy of the structure (eV)
@@ -268,6 +270,8 @@ class MoleculeRecord(Document):
 
         # Check all conformers
         for conf in self.conformers:
+            if optimized_only and (conf.config_name != config_name or conf.charge != charge):
+                continue
             energy_ind = conf.get_energy_index(config_name, charge, solvent)
             if energy_ind is not None and conf.energies[energy_ind].energy < lowest_energy:
                 stable_conformer = conf

--- a/tests/simulation/test_problem_recipes.py
+++ b/tests/simulation/test_problem_recipes.py
@@ -19,16 +19,19 @@ def simulator() -> ASESimulator:
 
 
 @mark.skipif(is_mac, reason='No xTB on OSX tests')
-def test_no_relaxed_charged(simulator: ASESimulator):
+@mark.parametrize('smiles,charge', [
+    ('N#CC1OC2CC2C1=O', 1),
+])
+def test_no_relaxed_charged(smiles: str, charge: int, simulator: ASESimulator):
     """A test where we do not create a new conformer after relaxation"""
 
     # Make the problem case
-    record = MoleculeRecord.from_identifier('N#CC1OC2CC2C1=O')
+    record = MoleculeRecord.from_identifier(smiles)
     recipes = [
-        RedoxEnergy(energy_config='mopac_pm7', charge=1, vertical=False),
-        RedoxEnergy(energy_config='mopac_pm7', charge=1, vertical=True),
-        RedoxEnergy(energy_config='xtb', charge=1, vertical=True),
-        RedoxEnergy(energy_config='xtb', charge=1, vertical=False)
+        RedoxEnergy(energy_config='xtb', charge=charge, vertical=True),
+        RedoxEnergy(energy_config='xtb', charge=charge, vertical=False),
+        RedoxEnergy(energy_config='mopac_pm7', charge=charge, vertical=False),
+        RedoxEnergy(energy_config='mopac_pm7', charge=charge, vertical=True),
     ]
 
     # Perform the recipe

--- a/tests/store/test_recipe.py
+++ b/tests/store/test_recipe.py
@@ -5,6 +5,7 @@ from math import isclose
 from pytest import raises
 from ase import units
 
+from examol.store.models import MissingData
 from examol.store.recipes import SolvationEnergy, RedoxEnergy
 
 
@@ -79,9 +80,9 @@ def test_redox_vacuum(record, sim_result):
     recipe = RedoxEnergy(1, 'test', vertical=False)
     assert 'adiabatic' in recipe.level
     assert 'oxid' in recipe.name
-    with raises(ValueError) as error:
+    with raises(MissingData) as error:
         recipe.compute_property(record)
-    assert 'We do not have a relaxed charged molecule' in str(error)
+    assert 'No data for config=test charge=1' in str(error.value)
 
     requests = recipe.suggest_computations(record)
     assert len(requests) == 1


### PR DESCRIPTION
Some molecules have poorly-converged results for vertical redox energies, which can make it appear the neutral geometry is lower in energy than the relaxed geometry for some molecules.

This commit adds a fix that ensureswe ignore the neutral geometry when computing adiabatic redox potentials.

Fixes #95 (again)