### PR TITLE
Refactor specifications and thinkers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
     'pytest-forked',
     'pytest-timeout',
     'pytest-cov',
+    'pytest-skip-slow'
 ]
 botorch = [
     'botorch==0.8.*'

--- a/tests/simulation/test_ase.py
+++ b/tests/simulation/test_ase.py
@@ -74,6 +74,7 @@ def test_cp2k_configs(tmpdir, strc):
 
 @mark.skipif(is_ci, reason='Too slow for CI')
 @mark.skipif(not has_cpk2, reason='CP2K is not installed')
+@mark.slow
 @mark.parametrize(
     'config,charge,solvent',
     [(xc, c, None) for xc, c in itertools.product(cp2k_configs_to_test, [0, 1])]  # Closed and open shell


### PR DESCRIPTION
Paving the way to add more strategies for steering simulations. The goal of this PR is to add a second steering strategy, a brute force search.

Checklist:
- [ ] Remove machine-learning-related settings from the specification
- [ ] Remove machine-learning-related components from the base thinker
- [ ] Add a brute force example
- [ ] Update documentation to explain new "Solution" classes