### PR TITLE
Write to temporary file, then copy

### DIFF
--- a/examol/store/db/base.py
+++ b/examol/store/db/base.py
@@ -80,7 +80,6 @@ class MoleculeStore(AbstractContextManager, ABC):
         Args:
             path: Path in which to save all data. Use a ".json.gz"
         """
-        logger.info(f'Started writing to {path}')
         with (gzip.open(path, 'wt') if path.name.endswith('.gz') else open(path, 'w')) as fp:
             for record in self.iterate_over_records():
                 print(record.json(), file=fp)

--- a/examol/store/db/memory.py
+++ b/examol/store/db/memory.py
@@ -106,8 +106,8 @@ class InMemoryStore(MoleculeStore):
             self._updates_available.clear()
 
             # Checkpoint and advance the standoff
-            temp_path = self.path.parent / (self.path.name + "-new")
-            logger.info(f'Started writing to {temp_path}')
+            temp_path = self.path.parent / ("new-" + self.path.name)
+            logger.info(f'Started writing {len(db)} records to {temp_path}')
             self.export_records(temp_path)
             move(temp_path, self.path)
             next_write = monotonic() + self.write_freq

--- a/examol/store/db/memory.py
+++ b/examol/store/db/memory.py
@@ -107,7 +107,7 @@ class InMemoryStore(MoleculeStore):
 
             # Checkpoint and advance the standoff
             temp_path = self.path.parent / ("new-" + self.path.name)
-            logger.info(f'Started writing {len(db)} records to {temp_path}')
+            logger.info(f'Started writing {len(self.db)} records to {temp_path}')
             self.export_records(temp_path)
             move(temp_path, self.path)
             next_write = monotonic() + self.write_freq

--- a/examol/store/db/memory.py
+++ b/examol/store/db/memory.py
@@ -32,7 +32,7 @@ class InMemoryStore(MoleculeStore):
         self.db: dict[str, MoleculeRecord] = {}
 
         # Start thread which writes until
-        self._thread_pool ThreadPoolExecutor | None = None
+        self._thread_pool: ThreadPoolExecutor | None = None
         self._write_thread: Future | None = None
         self._updates_available: Event = Event()
         self._closing = Event()

--- a/examol/store/db/memory.py
+++ b/examol/store/db/memory.py
@@ -1,11 +1,12 @@
 """Stores that keep the entire dataset in memory"""
 import gzip
 import logging
-from concurrent.futures import ThreadPoolExecutor, Future
+from shutil import move
 from pathlib import Path
-from time import monotonic, sleep
 from threading import Event
 from typing import Iterable
+from time import monotonic, sleep
+from concurrent.futures import ThreadPoolExecutor, Future
 
 from examol.store.db.base import MoleculeStore
 from examol.store.models import MoleculeRecord

--- a/examol/store/db/memory.py
+++ b/examol/store/db/memory.py
@@ -103,7 +103,9 @@ class InMemoryStore(MoleculeStore):
             self._updates_available.clear()
 
             # Checkpoint and advance the standoff
-            self.export_records(self.path)
+            temp_path = self.path.parent / (self.path.name + "-new")
+            self.export_records(temp_path)
+            move(temp_path, self.path)
             next_write = monotonic() + self.write_freq
 
     def update_record(self, record: MoleculeRecord):


### PR DESCRIPTION
This way, interrupting the write will not lead to the database file being corrupted.