### PR TITLE
Use Anaconda-provided CP2K

### DIFF
--- a/envs/environment-cpu.yml
+++ b/envs/environment-cpu.yml
@@ -17,6 +17,7 @@ dependencies:
   # Quantum chemistry codes
   - xtb-python==22.*
   - mopac
+  - cp2k
 
   # Use Conda PyTorch to avoid OpenMP disagreement
   #  with xTB


### PR DESCRIPTION
It has disappeared from Ubuntu 24.04 packages